### PR TITLE
fix(property): enabled required properties

### DIFF
--- a/src/classes/oas.generator.ts
+++ b/src/classes/oas.generator.ts
@@ -13,7 +13,7 @@ import {
   TsMethod,
   TsParameter,
   TsProgram,
-  TsProperty,
+  TsProperty
 } from '../lib/interfaces/tsmeta.schema'
 import { OasParameterGenerator } from './oas.generators/oas.parameter.generator'
 import { OasPathGenerator } from './oas.generators/oas.path.generator'
@@ -54,7 +54,7 @@ class OasGenerator {
       paths,
       security,
       servers,
-      tags,
+      tags
     }
   }
 
@@ -70,7 +70,7 @@ class OasGenerator {
           tsFile.tsClass &&
           tsFile.tsClass.decorators &&
           tsFile.tsClass.decorators.some(
-            (tsDecorator: TsDecorator) => tsDecorator.name === GetMappedAnnotation('Controller'),
+            (tsDecorator: TsDecorator) => tsDecorator.name === GetMappedAnnotation('Controller')
           )
         ) {
           tsFiles.push(tsFile)
@@ -93,7 +93,7 @@ class OasGenerator {
           tsFile.tsClass &&
           tsFile.tsClass.decorators &&
           tsFile.tsClass.decorators.some(
-            (tsDecorator: TsDecorator) => tsDecorator.name === GetMappedAnnotation('Model'),
+            (tsDecorator: TsDecorator) => tsDecorator.name === GetMappedAnnotation('Model')
           )
         ) {
           tsFiles.push(tsFile)
@@ -114,7 +114,7 @@ class OasGenerator {
 
     files.forEach((tsFile: TsFile) => {
       const controllerDecorator: TsDecorator = tsFile.tsClass.decorators.find(
-        (tsDecorator: TsDecorator) => tsDecorator.name === GetMappedAnnotation('Controller'),
+        (tsDecorator: TsDecorator) => tsDecorator.name === GetMappedAnnotation('Controller')
       )
       const controllerParams: Parameter[] = tsFile.tsClass.decorators
         .filter((tsDecorator: TsDecorator) => tsDecorator.name === GetMappedAnnotation('ControllerParam'))
@@ -126,7 +126,7 @@ class OasGenerator {
           tsFile.tsClass.name,
           controllerArgument.representation,
           tsMethod,
-          controllerParams,
+          controllerParams
         )
 
         paths = merge(paths, path)
@@ -147,8 +147,8 @@ class OasGenerator {
       name: controllerParamDecorator.tsarguments[0].representation.name,
       tstype: {
         basicType: 'string',
-        typescriptType: TypescriptTypes.BASIC,
-      },
+        typescriptType: TypescriptTypes.BASIC
+      }
     }
 
     return this.oasParameterGenerator.generate(tsParameter)
@@ -164,7 +164,7 @@ class OasGenerator {
 
     files.forEach((tsFile: TsFile) => {
       const modelDecorator: TsDecorator = tsFile.tsClass.decorators.find(
-        (tsDecorator: TsDecorator) => tsDecorator.name === GetMappedAnnotation('Model'),
+        (tsDecorator: TsDecorator) => tsDecorator.name === GetMappedAnnotation('Model')
       )
       const modelParam: ModelParam = modelDecorator.tsarguments
         ? modelDecorator.tsarguments.reduce(last).representation
@@ -173,13 +173,14 @@ class OasGenerator {
 
       const schemaName: string = `${tsFile.tsClass.name}${version}`
       let properties: { [key: string]: Schema } = {}
+      const required: string[] = []
 
       schemas[schemaName] = {}
 
       tsFile.tsClass.properties.forEach((tsProperty: TsProperty) => {
         properties = {
           ...properties,
-          ...this.oasSchemaGenerator.generate(modelParam, tsProperty),
+          ...this.oasSchemaGenerator.generate(modelParam, tsProperty, required)
         }
       })
 
@@ -188,7 +189,11 @@ class OasGenerator {
       schemas[schemaName] = {
         example,
         properties,
-        type: 'object',
+        type: 'object'
+      }
+
+      if (required.length > 0) {
+        schemas[schemaName].required = required
       }
     })
 

--- a/src/classes/oas.generators/oas.property.generator.ts
+++ b/src/classes/oas.generators/oas.property.generator.ts
@@ -10,7 +10,12 @@ class OasPropertyGenerator {
   /**
    * generate property schema
    */
-  public generate(tsProperty: TsProperty, propertyParam: PropertyParam, parameterParam?: ParameterParam): Schema {
+  public generate(
+    tsProperty: TsProperty,
+    propertyParam: PropertyParam,
+    parameterParam?: ParameterParam,
+    parentRequiredList?: string[]
+  ): Schema {
     let schema: Schema = {}
     const version: string = propertyParam && propertyParam.version ? `_${propertyParam.version}` : ''
 
@@ -54,6 +59,9 @@ class OasPropertyGenerator {
 
     if (propertyParam && propertyParam.format) schema.format = propertyParam.format as string
     if (propertyParam && propertyParam.enum) schema.enum = propertyParam.enum
+    if (propertyParam && propertyParam.required) {
+      parentRequiredList.push(tsProperty.name)
+    }
 
     return schema
   }

--- a/src/classes/oas.generators/oas.schema.generator.ts
+++ b/src/classes/oas.generators/oas.schema.generator.ts
@@ -15,7 +15,11 @@ class OasSchemaGenerator {
   /**
    * generate schema
    */
-  public generate(modelParam: ModelParam, tsProperty: TsProperty): { [key: string]: Schema } {
+  public generate(
+    modelParam: ModelParam,
+    tsProperty: TsProperty,
+    parentRequiredList: string[]
+  ): { [key: string]: Schema } {
     const schemaObj: { [key: string]: Schema } = {}
     let propertyDecorator: TsDecorator
     let propertyParam: PropertyParam
@@ -30,7 +34,12 @@ class OasSchemaGenerator {
 
     this.oasPropertyGenerator = new OasPropertyGenerator()
 
-    schemaObj[tsProperty.name] = this.oasPropertyGenerator.generate(tsProperty, propertyParam)
+    schemaObj[tsProperty.name] = this.oasPropertyGenerator.generate(
+      tsProperty,
+      propertyParam,
+      undefined,
+      parentRequiredList
+    )
     this.createSubSchema(tsProperty, propertyParam)
 
     return schemaObj


### PR DESCRIPTION
This commit adds the functionality to generate a valid model schema
with required properties.
This was a bug since we're already using required annotations for models
but they've never been marked as required in swagger doc.

- PTFRAMEW-706