### PR TITLE
feat(core): enforcedFormat arg for property decorator

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,93 @@
+version: 2
+
+defaults: &defaults
+  working_directory: ~/repo
+  docker:
+    - image: cimg/node:16
+
+jobs:
+  build:
+    <<: *defaults
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "package.json" }}
+            - v1-dependencies-
+      - run:
+          name: 'Install Dependencies'
+          command: 'yarn'
+      - run:
+          name: 'Build'
+          command: 'yarn build'
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package.json" }}
+      - persist_to_workspace:
+          root: ~/repo
+          paths: .
+  test:
+    <<: *defaults
+    steps:
+      - run:
+          name: 'Test'
+          command: 'echo "placeholder for test step"'
+      # - checkout
+      # - restore_cache:
+      #     keys:
+      #       - v1-dependencies-{{ checksum "package.json" }}
+      #       - v1-dependencies-
+      # - run:
+      #     name: 'Install Dependencies'
+      #     command: 'yarn'
+      # - run:
+      #     name: 'Run Tests'
+      #     command: 'yarn test'
+      # - save_cache:
+      #     paths:
+      #       - node_modules
+      #     key: v1-dependencies-{{ checksum "package.json" }}
+      # - persist_to_workspace:
+      #     root: ~/repo
+      #     paths: .
+  release:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/repo
+      - run:
+          name: Avoid hosts unknown for github
+          command: mkdir ~/.ssh/ && echo -e "Host github.com\n\tStrictHostKeyChecking no\n" > ~/.ssh/config
+      - run:
+          name: create-npmrc
+          command: |
+            echo "//npm.pkg.github.com/:_authToken=${GH_REGISTRY_TOKEN}" > ~/.npmrc
+            echo "@redteclab:registry=https://npm.pkg.github.com/" >> ~/.npmrc
+      - run:
+          name: Define environment variables
+          command: |
+            echo 'export GH_TOKEN=${GH_REGISTRY_TOKEN}' >> $BASH_ENV
+            source $BASH_ENV
+      - run: |
+          npm config set registry https://npm.pkg.github.com
+          npx semantic-release
+      - run:
+          name: remove npmrc
+          command: |
+            rm -f ~/.npmrc
+workflows:
+  version: 2
+  build-test-deploy:
+    jobs:
+      - build
+      - test:
+          requires:
+            - build
+      - release:
+          context: credentials
+          requires:
+            - test
+          filters:
+            branches:
+              only: master

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "tsmeta",
+  "name": "@redteclab/tsmeta",
   "main": "dist/index.js",
   "bin": "dist/bin.js",
   "source": "src/index.ts",
   "types": "dist/index.d.ts",
-  "version": "0.12.7",
+  "version": "0.13.0",
   "description": "typescript project meta analysis",
   "engines": {
     "node": "16.x.x"

--- a/src/classes/graphql.generators/graphql.property.generator.ts
+++ b/src/classes/graphql.generators/graphql.property.generator.ts
@@ -33,6 +33,11 @@ class GraphQLPropertyGenerator {
         ? (propertyArgument.representation as PropertyParam)
         : undefined
 
+    if (propertyParam?.enforcedFormat) {
+      const enforcedType: string = this.mapTypeToGraphQLType(propertyParam?.format)
+      return `${tsProperty.name}: ${enforcedType}`
+    }
+
     switch (tsType.typescriptType) {
       case TypescriptTypes.ARRAY:
         const arrayType: string =

--- a/src/lib/interfaces/annotation.schema.ts
+++ b/src/lib/interfaces/annotation.schema.ts
@@ -5,6 +5,12 @@ import { OasFormat } from '../enums/oas.format.enum'
 export interface PropertyParam {
   enum?: string[] // tslint:disable-line no-reserved-keywords
   format?: OasFormat
+  /**
+   * when dealing with types not already supported,
+   * we can simply use this property param to enforce the
+   * `format` above all other typedef meta handling logic
+   */
+  enforcedFormat?: boolean
   required?: boolean
   version?: string
 }


### PR DESCRIPTION
Certain properties have their Typescript TypeDef referenced from external libraries.

In some scenarios, these "remote types" are not well-understood by  graphql `buildSchema` ([example](https://stackoverflow.com/q/61243721/3429055)).

A quick solution, that's not too dirty, is to allow the user to enforce a specific type while bypassing all existing rules. This can be done by expanding the arguments for the `PropertyDecorator` as seen in the PR diff.